### PR TITLE
General simplifications

### DIFF
--- a/bin/imageoptim
+++ b/bin/imageoptim
@@ -4,16 +4,13 @@ readonly PATH_OPTIM="/Applications/ImageOptim.app/Contents/Frameworks/ImageOptim
 readonly PATH="$PATH:$PATH_OPTIM"
 
 function main() {
-  IFS=$' \t\n' read -e -a globs <<< "$1"
-  IFS=''
-  for glob in "${globs[@]}"; do
-    files=( $glob )
-    if [ ! -e "${files[@]}" ]; then
-      echo "Error: file or path '${files[@]}' not found!"
+  for file in "${@}"; do
+    if [ ! -e "${file}" ]; then
+      echo "Error: file or path '${file}' not found!"
       echo "Usage: $(basename "$0") <file or path>"
       exit 1
     else
-      process_input "${files[@]}"
+      process_input "${file}"
     fi
   done
 }

--- a/workflow/info.plist
+++ b/workflow/info.plist
@@ -8,7 +8,7 @@
 	<string>Tools</string>
 	<key>connections</key>
 	<dict>
-		<key>1B2FBD44-E195-44EB-9976-AC88094D6C13</key>
+		<key>833FE37A-C8D6-44B2-BDA2-B352644E2308</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
@@ -21,11 +21,11 @@
 				<false/>
 			</dict>
 		</array>
-		<key>833FE37A-C8D6-44B2-BDA2-B352644E2308</key>
+		<key>87EDAAB3-4D39-44FB-BA19-1ADCA5461925</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>1B2FBD44-E195-44EB-9976-AC88094D6C13</string>
+				<string>EF0F2B6E-A672-4EBD-AEFC-78E0EBEC0131</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -91,9 +91,9 @@
 				<key>escaping</key>
 				<integer>1</integer>
 				<key>script</key>
-				<string>./imageoptim "{query}"</string>
+				<string>./imageoptim "${@}"</string>
 				<key>scriptargtype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>scriptfile</key>
 				<string></string>
 				<key>type</key>
@@ -193,17 +193,13 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>addfilestobuffer</key>
-				<false/>
-				<key>clearbuffer</key>
-				<false/>
-				<key>outputtype</key>
-				<integer>0</integer>
+				<key>triggerid</key>
+				<string>optmize_image</string>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.action.buffer</string>
+			<string>alfred.workflow.trigger.external</string>
 			<key>uid</key>
-			<string>1B2FBD44-E195-44EB-9976-AC88094D6C13</string>
+			<string>87EDAAB3-4D39-44FB-BA19-1ADCA5461925</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -212,19 +208,19 @@
 	<string>An Alfred Workflow to compress images without losing quality.</string>
 	<key>uidata</key>
 	<dict>
-		<key>1B2FBD44-E195-44EB-9976-AC88094D6C13</key>
-		<dict>
-			<key>xpos</key>
-			<integer>325</integer>
-			<key>ypos</key>
-			<integer>170</integer>
-		</dict>
 		<key>833FE37A-C8D6-44B2-BDA2-B352644E2308</key>
 		<dict>
 			<key>xpos</key>
 			<integer>100</integer>
 			<key>ypos</key>
 			<integer>170</integer>
+		</dict>
+		<key>87EDAAB3-4D39-44FB-BA19-1ADCA5461925</key>
+		<dict>
+			<key>xpos</key>
+			<integer>100</integer>
+			<key>ypos</key>
+			<integer>325</integer>
 		</dict>
 		<key>CE8AA770-FD08-4A91-B13F-8531B5A8A849</key>
 		<dict>


### PR DESCRIPTION
The commit message isn’t great but these are a bunch of small corrections to things you’re doing the hard way.

You shouldn’t use `with input as {query}`, but `with input as argv`. With that change we shave three lines out of the script. Not only does it become simpler, it’s more robust. This is the proper way to handle multiple arguments and paths in bash and in Alfred, you don’t need to mess with IFS.

The File Buffer object is extraneous. You’re using it to process multiple files but that’s not what it’s for an it isn’t necessary for that, you can just use a File Action in multiple actions like normal.

I’ve also added an External Trigger, so people can invoke the optimisation from other Workflows. This is what prompted the PR, due to https://www.alfredforum.com/topic/17804-process-screenshots-w-imageoptim/.

I’ve only updated the files, not the Workflow file itself, because GitHub wouldn’t show the modifications to that.

If you want to add auto-updating capabilities to the Workflow, [I can help with that as well](https://www.alfredforum.com/topic/9224-oneupdater-—-update-workflows-with-a-single-node/).